### PR TITLE
remove unnecessary find_package call

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,6 @@ project(rqt_console)
 # Load ament and all dependencies required for this package
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_python REQUIRED)
-# Note: This is needed for rcl_interfaces Log.msg
-find_package(rcl_interfaces REQUIRED)
 
 ament_python_install_package(${PROJECT_NAME}
     PACKAGE_DIR src/${PROJECT_NAME})


### PR DESCRIPTION
Follow up of #8.

There is no build dependency on `rcl_interfaces` and therefore the released package fails to build: http://build.ros2.org/view/Cbin_uB64/job/Cbin_uB64__rqt_console__ubuntu_bionic_amd64__binary/1/

There is no need to `find_package` that dependency in CMake.