### PR TITLE
Add context menu for hiding and showing columns

### DIFF
--- a/src/rqt_console/console_widget.py
+++ b/src/rqt_console/console_widget.py
@@ -750,14 +750,17 @@ class ConsoleWidget(QWidget):
         self.table_view.resizeColumnsToContents()
 
     def _handle_column_right_click(self, pos):
-        column = self.table_view.horizontalHeader().logicalIndexAt(pos.x())
-
-        # show menu about the column
         menu = QMenu(self)
         hide = menu.addAction('Hide Column')
         showall = menu.addAction('Show all columns')
+
+        # Don't allow hiding the last column
+        if self.table_view.horizontalHeader().count() - self.table_view.horizontalHeader().hiddenSectionCount() == 1:
+            hide.setEnabled(False)
+
         ac = menu.exec_(self.table_view.horizontalHeader().mapToGlobal(pos))
         if ac == hide:
+            column = self.table_view.horizontalHeader().logicalIndexAt(pos.x())
             self.table_view.horizontalHeader().hideSection(column)
         elif ac == showall:
             for i in range(self.table_view.horizontalHeader().count()):

--- a/src/rqt_console/console_widget.py
+++ b/src/rqt_console/console_widget.py
@@ -111,6 +111,9 @@ class ConsoleWidget(QWidget):
             self.table_view.horizontalHeader().setSortIndicatorShown(logical_index != 0)
         self.table_view.horizontalHeader().sortIndicatorChanged.connect(update_sort_indicator)
 
+        self.table_view.horizontalHeader().setContextMenuPolicy(Qt.CustomContextMenu)
+        self.table_view.horizontalHeader().customContextMenuRequested.connect(self._handle_column_right_click)
+
         self.add_exclude_button.setIcon(QIcon.fromTheme('list-add'))
         self.add_highlight_button.setIcon(QIcon.fromTheme('list-add'))
         self.pause_button.setIcon(QIcon.fromTheme('media-playback-pause'))
@@ -745,6 +748,20 @@ class ConsoleWidget(QWidget):
 
     def _handle_column_resize_clicked(self):
         self.table_view.resizeColumnsToContents()
+
+    def _handle_column_right_click(self, pos):
+        column = self.table_view.horizontalHeader().logicalIndexAt(pos.x())
+
+        # show menu about the column
+        menu = QMenu(self)
+        hide = menu.addAction('Hide Column')
+        showall = menu.addAction('Show all columns')
+        ac = menu.exec_(self.table_view.horizontalHeader().mapToGlobal(pos))
+        if ac == hide:
+            self.table_view.horizontalHeader().hideSection(column)
+        elif ac == showall:
+            for i in range(self.table_view.horizontalHeader().count()):
+                self.table_view.horizontalHeader().showSection(i)
 
     def _delete_selected_rows(self):
         rowlist = []


### PR DESCRIPTION
Using rqt_console next to for example rviz restricts the amount of horizontal space. I found myself frequently resizing the topic and location columns to their minimum size to still have some space for the actual message.

This change allows for hiding columns by adding a context menu on the header with 2 options: `Hide column` and `Show all columns`.