### PR TITLE
[fix]handle_pause_clicked doesn't need args

### DIFF
--- a/src/rqt_console/console_widget.py
+++ b/src/rqt_console/console_widget.py
@@ -690,7 +690,7 @@ class ConsoleWidget(QWidget):
             if messages:
                 self._model.insert_rows(messages)
 
-                self._handle_pause_clicked(True)
+                self._handle_pause_clicked()
 
             return True
 


### PR DESCRIPTION
__Summary__
  handle_pause_clicked doesn't have arg, but set.
* Change files
  modified:   src/rqt_console/console_widget.py