### PR TITLE
Use catkin_install_python()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,6 @@ install(DIRECTORY resource
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
 
-install(PROGRAMS scripts/rqt_console
+catkin_install_python(PROGRAMS scripts/rqt_console
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,7 @@ from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(
     packages=['rqt_console', 'rqt_console.filters'],
-    package_dir={'': 'src'},
-    scripts=['scripts/rqt_console']
+    package_dir={'': 'src'}
 )
 
 setup(**d)


### PR DESCRIPTION
Similar to ros-visualization/rqt_graph#43

This uses catkin_install_python() instead of a mix of install and the setup.py scripts argument to make sure the shebang gets rewritten.

It fixes a bug in the current debian package I encountered here: http://wiki.ros.org/ROS/Tutorials/UsingRqtconsoleRoslaunch#Using_rqt_console_and_rqt_logger_level

```console
$ rosrun rqt_console rqt_console
/usr/bin/env: ‘python’: No such file or directory
```