### PR TITLE
Fix arg to _add_highlight_filter to avoid KeyError

### DIFF
--- a/src/rqt_console/console_widget.py
+++ b/src/rqt_console/console_widget.py
@@ -464,7 +464,7 @@ class ConsoleWidget(QWidget):
                 # Test if the filter we are adding already exists if it does use the existing filter
                 if self.filter_factory[selectiontype.lower()][1] not in \
                         [type(item) for sublist in self._highlight_filters for item in sublist]:
-                    filter_index = self._add_highlight_filter(col)
+                    filter_index = self._add_highlight_filter(selectiontype.lower())
                 else:
                     for index, item in enumerate(self._highlight_filters):
                         if type(item[0]) == self.filter_factory[selectiontype.lower()][1]:


### PR DESCRIPTION
When I was using `rqt_console` and tried to do node highlight, I faced the following KeyError.
So I fixed argument to `_add_highlight_filter` to avoid the KeyError.

```
$ rqt_console
Traceback (most recent call last):
  File "/home/leus/catkin_workspace/src/rqt_console/src/rqt_console/console_widget.py", line 805, in _handle_mouse_press
    self._rightclick_menu(event)
  File "/home/leus/catkin_workspace/src/rqt_console/src/rqt_console/console_widget.py", line 560, in _rightclick_menu
    action.text(), action.parentWidget().title(), False)
  File "/home/leus/catkin_workspace/src/rqt_console/src/rqt_console/console_widget.py", line 467, in _process_highlight_exclude_filter
    filter_index = self._add_highlight_filter(col)
  File "/home/leus/catkin_workspace/src/rqt_console/src/rqt_console/console_widget.py", line 330, in _add_highlight_filter
    newfilter = self.filter_factory[filter_index][1]()
KeyError: 2
Aborted (core dumped)
```

![highlight_error](https://user-images.githubusercontent.com/19769486/104089247-ade32b80-52b0-11eb-815a-c77ffaa426fa.png)
