### PR TITLE
Use underscores in setup.cfg instead of dashes

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/rqt_console
+script_dir=$base/lib/rqt_console
 [install]
-install-scripts=$base/lib/rqt_console
+install_scripts=$base/lib/rqt_console


### PR DESCRIPTION
In the same vein as https://github.com/ros2/ros2cli/pull/627. Affects the [Using rqt console](https://docs.ros.org/en/rolling/Tutorials/Rqt-Console/Using-Rqt-Console.html) tutorial.

CI up to `rqt_console`:

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=14464)](http://ci.ros2.org/job/ci_linux/14464/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=9232)](http://ci.ros2.org/job/ci_linux-aarch64/9232/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=12133)](http://ci.ros2.org/job/ci_osx/12133/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=14565)](http://ci.ros2.org/job/ci_windows/14565/)
