### PR TITLE
Fix issue 33:  UnicodeDecodeError when parsing strings containing Japanese characters

### DIFF
--- a/src/rqt_console/message.py
+++ b/src/rqt_console/message.py
@@ -34,6 +34,9 @@ from rosgraph_msgs.msg import Log
 
 from python_qt_binding.QtCore import QCoreApplication, QDateTime, QObject
 
+# This is needed to check the python version in order to
+# solve https://github.com/ros-visualization/rqt_console/issues/33 
+from sys import version_info
 
 class Message(QObject):
 
@@ -125,7 +128,11 @@ class Message(QObject):
         text += self.tr('Time: ') + self.get_stamp_string() + '\n'
         text += self.tr('Severity: ') + Message.SEVERITY_LABELS[self.severity] + '\n'
         text += self.tr('Published Topics: ') + ', '.join(self.topics) + '\n'
-        text += '\n' + self.message.decode('utf-8') + '\n'
+        # Python version is checked here in order to solve 
+        # https://github.com/ros-visualization/rqt_console/issues/33
+        # Python 2 requres the data to be decoded to avoid crash when the string contains
+        # non-ascii characters. In Python 3 and above, this is not an issue
+        text += '\n' + self.message.decode('utf-8') if version_info[0] < 3 else self.message + '\n'
         text += '\n' + 'Location:'
         text += '\n' + self.location + '\n\n'
         text += '-' * 100 + '\n\n'

--- a/src/rqt_console/message.py
+++ b/src/rqt_console/message.py
@@ -130,7 +130,7 @@ class Message(QObject):
         text += self.tr('Published Topics: ') + ', '.join(self.topics) + '\n'
         # Python version is checked here in order to solve 
         # https://github.com/ros-visualization/rqt_console/issues/33
-        # Python 2 requres the data to be decoded to avoid crash when the string contains
+        # Python 2 requires the data to be decoded to avoid crash when the string contains
         # non-ascii characters. In Python 3 and above, this is not an issue
         text += '\n' + self.message.decode('utf-8') if version_info[0] < 3 else self.message + '\n'
         text += '\n' + 'Location:'

--- a/src/rqt_console/message.py
+++ b/src/rqt_console/message.py
@@ -125,7 +125,7 @@ class Message(QObject):
         text += self.tr('Time: ') + self.get_stamp_string() + '\n'
         text += self.tr('Severity: ') + Message.SEVERITY_LABELS[self.severity] + '\n'
         text += self.tr('Published Topics: ') + ', '.join(self.topics) + '\n'
-        text += '\n' + self.message + '\n'
+        text += '\n' + self.message.decode('utf-8') + '\n'
         text += '\n' + 'Location:'
         text += '\n' + self.location + '\n\n'
         text += '-' * 100 + '\n\n'

--- a/src/rqt_console/message_data_model.py
+++ b/src/rqt_console/message_data_model.py
@@ -36,6 +36,9 @@ from python_qt_binding.QtGui import QBrush, QIcon
 from .message import Message
 from .message_list import MessageList
 
+# This is needed to check the python version in order to
+# solve https://github.com/ros-visualization/rqt_console/issues/33 
+from sys import version_info
 
 class MessageDataModel(QAbstractTableModel):
 
@@ -121,7 +124,11 @@ class MessageDataModel(QAbstractTableModel):
                     else:
                         data = getattr(msg, column)
                     # <font> tag enables word wrap by forcing rich text
-                    return '<font>' + data.decode('utf-8') + '<br/><br/>' + \
+                    # Python version is checked here in order to solve 
+                    # https://github.com/ros-visualization/rqt_console/issues/33
+                    # Python 2 requres the data to be decoded to avoid crash when the string contains
+                    # non-ascii characters. In Python 3 and above, this is not an issue
+                    return '<font>' + data.decode('utf-8') if version_info[0] < 3 else data + '<br/><br/>' + \
                         self.tr('Right click for menu.') + '</font>'
 
     def headerData(self, section, orientation, role=None):

--- a/src/rqt_console/message_data_model.py
+++ b/src/rqt_console/message_data_model.py
@@ -121,7 +121,7 @@ class MessageDataModel(QAbstractTableModel):
                     else:
                         data = getattr(msg, column)
                     # <font> tag enables word wrap by forcing rich text
-                    return '<font>' + data + '<br/><br/>' + \
+                    return '<font>' + data.decode('utf-8') + '<br/><br/>' + \
                         self.tr('Right click for menu.') + '</font>'
 
     def headerData(self, section, orientation, role=None):

--- a/src/rqt_console/message_data_model.py
+++ b/src/rqt_console/message_data_model.py
@@ -126,7 +126,7 @@ class MessageDataModel(QAbstractTableModel):
                     # <font> tag enables word wrap by forcing rich text
                     # Python version is checked here in order to solve 
                     # https://github.com/ros-visualization/rqt_console/issues/33
-                    # Python 2 requres the data to be decoded to avoid crash when the string contains
+                    # Python 2 requires the data to be decoded to avoid crash when the string contains
                     # non-ascii characters. In Python 3 and above, this is not an issue
                     return '<font>' + data.decode('utf-8') if version_info[0] < 3 else data + '<br/><br/>' + \
                         self.tr('Right click for menu.') + '</font>'


### PR DESCRIPTION
This PR closes #33 by decoding utf-8 data and messages to avoid the rqt_console from crashing when double clicking a message with Japanese characters.