### PR TITLE
Add a tick box to show relative timestamps

### DIFF
--- a/resource/console_widget.ui
+++ b/resource/console_widget.ui
@@ -110,6 +110,16 @@
       </spacer>
      </item>
      <item>
+      <widget class="QCheckBox" name="dt_box">
+       <property name="toolTip">
+        <string>Toggle absolute/relative time stamps</string>
+       </property>
+       <property name="text">
+        <string>Δt</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QPushButton" name="clear_button">
        <property name="text">
         <string>Clear</string>

--- a/src/rqt_console/console_widget.py
+++ b/src/rqt_console/console_widget.py
@@ -142,9 +142,11 @@ class ConsoleWidget(QWidget):
         self.save_button.clicked[bool].connect(self._handle_save_clicked)
         self.column_resize_button.clicked[bool].connect(self._handle_column_resize_clicked)
         self.clear_button.clicked[bool].connect(self._handle_clear_button_clicked)
+        self.dt_box.stateChanged.connect(self._handle_dt_box_clicked)
 
         self.table_view.mouseDoubleClickEvent = self._handle_mouse_double_click
         self.table_view.mousePressEvent = self._handle_mouse_press
+        self.table_view.mouseReleaseEvent = self._handle_mouse_release
         self.table_view.keyPressEvent = self._handle_custom_keypress
 
         self.highlight_exclude_button.clicked[bool].connect(
@@ -587,6 +589,9 @@ class ConsoleWidget(QWidget):
         self._model.remove_rows([])
         Message._next_id = 1
 
+    def _handle_dt_box_clicked(self):
+        self._model.relative_timestamps = self.dt_box.isChecked()
+
     def _handle_load_clicked(self, checked):
         filename = QFileDialog.getOpenFileName(
             self, self.tr('Load from File'), '.',
@@ -797,6 +802,13 @@ class ConsoleWidget(QWidget):
         if event.buttons() & Qt.RightButton and event.modifiers() == Qt.NoModifier:
             self._rightclick_menu(event)
             event.accept()
+
+    def _handle_mouse_release(self, event, old_pressEvent=QTableView.mousePressEvent):
+        # Get the row as the time origin.
+        indexes = self.table_view.selectionModel().selectedIndexes()
+        if indexes:
+            message_index = self._proxy_model.mapToSource(indexes[0]).row()
+            self._model.set_index_relative_to(message_index)
         return old_pressEvent(self.table_view, event)
 
     def save_settings(self, plugin_settings, instance_settings):

--- a/src/rqt_console/message.py
+++ b/src/rqt_console/message.py
@@ -33,6 +33,12 @@
 from python_qt_binding.QtCore import QCoreApplication, QDateTime, QObject
 
 
+def time_diff(stamp1: tuple[int, int], stamp2: tuple[int, int]) -> float:
+    t1_ns = stamp1[0] * 1e9 + stamp1[1]
+    t2_ns = stamp2[0] * 1e9 + stamp2[1]
+    return (t2_ns - t1_ns) / 1e9
+
+
 class Message(QObject):
 
     DEBUG = 10
@@ -109,7 +115,9 @@ class Message(QObject):
         dt.addMSecs(int(float(stamp[1]) / 10**6))
         return dt
 
-    def get_stamp_string(self):
+    def get_stamp_string(self, relative_to: 'Message' = None):
+        if relative_to:
+            return f'{time_diff(relative_to.stamp, self.stamp):.6f}'
         return self._stamp_string
 
     def set_stamp_format(self, stamp_format):

--- a/src/rqt_console/message_data_model.py
+++ b/src/rqt_console/message_data_model.py
@@ -30,6 +30,8 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from typing import Optional
+
 from python_qt_binding.QtCore import QAbstractTableModel, QModelIndex, Qt, qWarning
 from python_qt_binding.QtGui import QBrush, QIcon
 
@@ -54,6 +56,8 @@ class MessageDataModel(QAbstractTableModel):
         super(MessageDataModel, self).__init__()
         self._messages = MessageList()
         self._message_limit = 20000
+        self._relative_timestamps = False
+        self._relative_to: Optional[int] = None
         self._info_icon = QIcon.fromTheme('dialog-information')
         self._warning_icon = QIcon.fromTheme('dialog-warning')
         self._error_icon = QIcon.fromTheme('dialog-error')
@@ -79,7 +83,11 @@ class MessageDataModel(QAbstractTableModel):
                 if role == Qt.DisplayRole or role == Qt.UserRole:
                     if column == 'stamp':
                         if role != Qt.UserRole:
-                            data = msg.get_stamp_string()
+                            if self._relative_timestamps and (self._relative_to is not None) and (index.row() != self._relative_to):
+                                relative_to = self._messages[self._relative_to]
+                                data = msg.get_stamp_string(relative_to)
+                            else:
+                                data = msg.get_stamp_string()
                         else:
                             data = msg.get_stamp_for_compare()
                     else:
@@ -137,6 +145,24 @@ class MessageDataModel(QAbstractTableModel):
                         'interaction especially when recording high frequency data')
 
     # END Required implementations of QAbstractTableModel functions
+
+    @property
+    def relative_timestamps(self):
+        return self._relative_timestamps
+
+    @relative_timestamps.setter
+    def relative_timestamps(self, value):
+        self._relative_timestamps = bool(value)
+        top_row = self.index(0, self.columns.index('stamp'))
+        bottom_row = self.index(self.rowCount() - 1, top_row.column())
+        self.dataChanged.emit(top_row, bottom_row)
+
+    def set_index_relative_to(self, index: int):
+        if 0 <= index < len(self._messages):
+            self._relative_to = index
+            top_row = self.index(0, self.columns.index('stamp'))
+            bottom_row = self.index(self.rowCount() - 1, top_row.column())
+            self.dataChanged.emit(top_row, bottom_row)
 
     def get_message_limit(self):
         return self._message_limit


### PR DESCRIPTION
Add a tick box to show timestamps relative to the selection.

In mode "relative timestamps", the selected line (or the first line if more lines are selected) is show with the absolute timestamp. Timestamps of other lines are shown as the time relative to the selected line in seconds ("+" means younger event, "-" means older event).