### PR TITLE
basic support for colors and bold/bright

### DIFF
--- a/resource/console_settings_dialog.ui
+++ b/resource/console_settings_dialog.ui
@@ -10,73 +10,75 @@
     <x>0</x>
     <y>0</y>
     <width>368</width>
-    <height>123</height>
+    <height>147</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Setup</string>
   </property>
+  <property name="sizeGripEnabled">
+   <bool>false</bool>
+  </property>
   <property name="modal">
    <bool>true</bool>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
-     <item>
-      <widget class="QLabel" name="label">
-       <property name="maximumSize">
-        <size>
-         <width>94</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>Rosout Topic</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QComboBox" name="topic_combo"/>
-     </item>
-    </layout>
+  <layout class="QFormLayout" name="formLayout">
+   <item row="1" column="0">
+    <widget class="QLabel" name="topic_label">
+     <property name="maximumSize">
+      <size>
+       <width>94</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>Rosout Topic</string>
+     </property>
+    </widget>
    </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QLabel" name="label_5">
-       <property name="maximumSize">
-        <size>
-         <width>94</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>Buffer Size</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QSpinBox" name="buffer_size_spin">
-       <property name="maximum">
-        <number>100000</number>
-       </property>
-       <property name="singleStep">
-        <number>1000</number>
-       </property>
-       <property name="value">
-        <number>20000</number>
-       </property>
-      </widget>
-     </item>
-    </layout>
+   <item row="1" column="1">
+    <widget class="QComboBox" name="topic_combo"/>
    </item>
-   <item>
-    <layout class="QHBoxLayout" name="levelsLayout"/>
+   <item row="2" column="0">
+    <widget class="QLabel" name="buffer_size_label">
+     <property name="maximumSize">
+      <size>
+       <width>94</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>Buffer Size</string>
+     </property>
+    </widget>
    </item>
-   <item>
+   <item row="2" column="1">
+    <widget class="QSpinBox" name="buffer_size_spin">
+     <property name="maximum">
+      <number>100000</number>
+     </property>
+     <property name="singleStep">
+      <number>1000</number>
+     </property>
+     <property name="value">
+      <number>20000</number>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="standardButtons">
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QCheckBox" name="colors_checkbox">
+     <property name="text">
+      <string>Show ANSII Colors</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
      </property>
     </widget>
    </item>

--- a/resource/console_widget.ui
+++ b/resource/console_widget.ui
@@ -17,7 +17,16 @@
    <property name="spacing">
     <number>4</number>
    </property>
-   <property name="margin">
+   <property name="leftMargin">
+    <number>5</number>
+   </property>
+   <property name="topMargin">
+    <number>5</number>
+   </property>
+   <property name="rightMargin">
+    <number>5</number>
+   </property>
+   <property name="bottomMargin">
     <number>5</number>
    </property>
    <item>
@@ -149,7 +158,7 @@
             <bool>true</bool>
            </property>
            <property name="selectionBehavior">
-            <enum>QAbstractItemView::SelectRows</enum>
+            <enum>QAbstractItemView::SelectItems</enum>
            </property>
            <property name="iconSize">
             <size>

--- a/src/rqt_console/console.py
+++ b/src/rqt_console/console.py
@@ -136,12 +136,13 @@ class Console(Plugin):
         ])
 
         dialog = ConsoleSettingsDialog(topics)
-        (topic, message_limit) = dialog.query(self._topic, self._model.get_message_limit())
+        topic, message_limit, colors_enabled = dialog.query(self._topic, self._model.get_message_limit(), self._model.get_colors_enabled())
         if topic != self._topic:
             self._subscribe(topic)
         if message_limit != self._model.get_message_limit():
             self._model.set_message_limit(message_limit)
-
+        if colors_enabled != self._model.get_colors_enabled():
+            self._model.set_colors_enabled(colors_enabled)
     def _subscribe(self, topic):
         if self._subscriber:
             self._context.node.destroy_subscription(self._subscriber)

--- a/src/rqt_console/console_settings_dialog.py
+++ b/src/rqt_console/console_settings_dialog.py
@@ -59,15 +59,17 @@ class ConsoleSettingsDialog(QDialog):
 
         self.adjustSize()
 
-    def query(self, topic, buffer_size):
+    def query(self, topic, buffer_size, colors_enabled):
         index = self.topic_combo.findData(topic)
         if index != -1:
             self.topic_combo.setCurrentIndex(index)
         self.buffer_size_spin.setValue(buffer_size)
+        self.colors_checkbox.setChecked(colors_enabled)
         ok = self.exec_()
         if ok == 1:
             index = self.topic_combo.currentIndex()
             if index != -1:
                 topic = self.topic_combo.itemData(index)
             buffer_size = self.buffer_size_spin.value()
-        return topic, buffer_size
+            colors_enabled = self.colors_checkbox.isChecked()
+        return topic, buffer_size, colors_enabled

--- a/src/rqt_console/console_widget.py
+++ b/src/rqt_console/console_widget.py
@@ -828,6 +828,8 @@ class ConsoleWidget(QWidget):
         instance_settings.set_value('highlight_filters', pack(highlight_filters))
         instance_settings.set_value('message_limit', self._model.get_message_limit())
 
+        instance_settings.set_value('colors_enabled', self._model.get_colors_enabled())
+
     def restore_settings(self, pluggin_settings, instance_settings):
         if instance_settings.contains('table_splitter'):
             self.table_splitter.restoreState(instance_settings.value('table_splitter'))
@@ -875,3 +877,7 @@ class ConsoleWidget(QWidget):
 
         if instance_settings.contains('message_limit'):
             self._model.set_message_limit(int(instance_settings.value('message_limit')))
+
+        if instance_settings.contains('colors_enabled'):
+            colors_enabled = instance_settings.value('colors_enabled') in [True, 'true']
+            self._model.set_colors_enabled(colors_enabled)

--- a/src/rqt_console/message_data_model.py
+++ b/src/rqt_console/message_data_model.py
@@ -76,8 +76,8 @@ def ansi_foreground(data):
     # returns the foreground color to be used for data
     for m in re.finditer(r"\x1b\[(?P<int>\d+)m", data):
         attribute = int(m.group("int"))
-        if 30 <= attribute <= 37:
-            color_index = attribute - 30
+        if 30 <= attribute <= 37 or 90 <= attribute <= 97:
+            color_index = attribute % 30
             if color_index == 0:
                 color = Qt.black
             elif color_index == 1:

--- a/src/rqt_console/message_data_model.py
+++ b/src/rqt_console/message_data_model.py
@@ -120,6 +120,7 @@ class MessageDataModel(QAbstractTableModel):
         super(MessageDataModel, self).__init__()
         self._messages = MessageList()
         self._message_limit = 20000
+        self._colors_enabled = True
         self._info_icon = QIcon.fromTheme('dialog-information')
         self._warning_icon = QIcon.fromTheme('dialog-warning')
         self._error_icon = QIcon.fromTheme('dialog-error')
@@ -153,12 +154,10 @@ class MessageDataModel(QAbstractTableModel):
                     # map severity enum to label
                     if role == Qt.DisplayRole and column == 'severity':
                         data = Message.SEVERITY_LABELS[data]
-                    # remove ansii codes
+                    # remove ANSI codes
                     if column == 'message':
-                        data = filter_ansi_codes(data)
-                    # implode topic names
-                    if column == 'topics':
-                        data = ', '.join(data)
+                        if self._colors_enabled:
+                            data = filter_ansi_codes(data)
                     # append row number to define strict order
                     if role == Qt.UserRole:
                         # append row number to define strict order
@@ -191,15 +190,16 @@ class MessageDataModel(QAbstractTableModel):
                         self.tr('Right click for menu.') + '</font>'
 
                 # handle some of the ANSI codes
-                if role == Qt.ForegroundRole and column == 'message':
-                    data = ansi_foreground(msg.message)
-                    return data
-                if role == Qt.FontRole and column == 'message':
-                    data = ansi_font_properties(msg.message)
-                    return data
-                if role == Qt.BackgroundRole and column == 'message':
-                    data = ansi_background(msg.message)
-                    return data
+                if self._colors_enabled:
+                    if role == Qt.ForegroundRole and column == 'message':
+                        data = ansi_foreground(msg.message)
+                        return data
+                    if role == Qt.FontRole and column == 'message':
+                        data = ansi_font_properties(msg.message)
+                        return data
+                    if role == Qt.BackgroundRole and column == 'message':
+                        data = ansi_background(msg.message)
+                        return data
 
     def headerData(self, section, orientation, role=None):
         if role is None:
@@ -223,9 +223,15 @@ class MessageDataModel(QAbstractTableModel):
     def get_message_limit(self):
         return self._message_limit
 
+    def get_colors_enabled(self):
+        return self._colors_enabled
+
     def set_message_limit(self, new_limit):
         self._message_limit = new_limit
         self._enforce_message_limit(self._message_limit)
+
+    def set_colors_enabled(self, enabled):
+        self._colors_enabled = enabled
 
     def _enforce_message_limit(self, limit):
         if len(self._messages) > limit:

--- a/src/rqt_console/message_data_model.py
+++ b/src/rqt_console/message_data_model.py
@@ -29,14 +29,82 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 from python_qt_binding.QtCore import QAbstractTableModel, QModelIndex, Qt
-from python_qt_binding.QtGui import QBrush, QIcon
+from python_qt_binding.QtGui import QBrush, QIcon, QFont, QColor
+import re
 
 from .message import Message
 from .message_list import MessageList
 
 
-class MessageDataModel(QAbstractTableModel):
+def ansi_background(data):
+    for m in re.finditer(r"\x1b\[(?P<int>\d+)m", data):
+        attribute = int(m.group("int"))
+        if 40 <= attribute <= 47:
+            color_index = attribute - 40
+            if color_index == 0:
+                color = Qt.black
+            elif color_index == 1:
+                color = Qt.red
+            elif color_index == 2:
+                color = Qt.green
+            elif color_index == 3:
+                color = Qt.yellow
+            elif color_index == 4:
+                color = Qt.blue
+            elif color_index == 5:
+                color = Qt.magenta
+            elif color_index == 6:
+                color = Qt.cyan
+            elif color_index == 7:
+                color = Qt.white
+            else:
+                raise NotImplementedError()
+            return QColor(color)
+    return None
 
+
+def ansi_font_properties(data):
+    font = QFont()
+    for m in re.finditer(r"\x1b\[(?P<int>\d+)m", data):
+        attribute = int(m.group("int"))
+        if attribute == 1:
+            font.setBold(True)
+    return font
+
+
+def ansi_foreground(data):
+    # returns the foreground color to be used for data
+    for m in re.finditer(r"\x1b\[(?P<int>\d+)m", data):
+        attribute = int(m.group("int"))
+        if 30 <= attribute <= 37:
+            color_index = attribute - 30
+            if color_index == 0:
+                color = Qt.black
+            elif color_index == 1:
+                color = Qt.red
+            elif color_index == 2:
+                color = Qt.green
+            elif color_index == 3:
+                color = Qt.yellow
+            elif color_index == 4:
+                color = Qt.blue
+            elif color_index == 5:
+                color = Qt.magenta
+            elif color_index == 6:
+                color = Qt.cyan
+            elif color_index == 7:
+                color = Qt.white
+            else:
+                raise NotImplementedError()
+            return QBrush(color)
+    return None
+
+
+def filter_ansi_codes(data):
+    return re.sub(r"\x1b\[(?P<int>\d+)m", "", data)
+
+
+class MessageDataModel(QAbstractTableModel):
     # the column names must match the message attributes
     columns = ['message', 'severity', 'node', 'stamp', 'location']
 
@@ -85,6 +153,12 @@ class MessageDataModel(QAbstractTableModel):
                     # map severity enum to label
                     if role == Qt.DisplayRole and column == 'severity':
                         data = Message.SEVERITY_LABELS[data]
+                    # remove ansii codes
+                    if column == 'message':
+                        data = filter_ansi_codes(data)
+                    # implode topic names
+                    if column == 'topics':
+                        data = ', '.join(data)
                     # append row number to define strict order
                     if role == Qt.UserRole:
                         # append row number to define strict order
@@ -115,6 +189,17 @@ class MessageDataModel(QAbstractTableModel):
                     # <font> tag enables word wrap by forcing rich text
                     return '<font>' + data + '<br/><br/>' + \
                         self.tr('Right click for menu.') + '</font>'
+
+                # handle some of the ANSI codes
+                if role == Qt.ForegroundRole and column == 'message':
+                    data = ansi_foreground(msg.message)
+                    return data
+                if role == Qt.FontRole and column == 'message':
+                    data = ansi_font_properties(msg.message)
+                    return data
+                if role == Qt.BackgroundRole and column == 'message':
+                    data = ansi_background(msg.message)
+                    return data
 
     def headerData(self, section, orientation, role=None):
         if role is None:

--- a/test/test_colorama_logging.py
+++ b/test/test_colorama_logging.py
@@ -1,0 +1,22 @@
+import rclpy
+from rclpy.node import Node
+import colorama
+from colorama import Fore, Style, init
+
+rclpy.init()
+
+n = Node('test_logging')
+
+colorama.init(autoreset=True)
+
+n.get_logger().info("normal")
+n.get_logger().info(Fore.RED + Style.BRIGHT + "bold and red!")
+n.get_logger().info("normal again")
+
+n.get_logger().warning("normal")
+n.get_logger().warning(Fore.RED + Style.BRIGHT + "bold and red!")
+n.get_logger().warning("normal again")
+
+n.get_logger().error("normal")
+n.get_logger().error(Fore.RED + Style.BRIGHT + "bold and red!")
+n.get_logger().error("normal again")

--- a/test/test_colorama_logging.py
+++ b/test/test_colorama_logging.py
@@ -1,3 +1,4 @@
+import time
 import rclpy
 from rclpy.node import Node
 import colorama
@@ -20,3 +21,6 @@ n.get_logger().warning("normal again")
 n.get_logger().error("normal")
 n.get_logger().error(Fore.RED + Style.BRIGHT + "bold and red!")
 n.get_logger().error("normal again")
+
+# Ensure the messages make it to rosout before the script dies
+time.sleep(1)

--- a/test/test_colored_logging.py
+++ b/test/test_colored_logging.py
@@ -2,7 +2,7 @@ import time
 import rclpy
 from rclpy.node import Node
 import colorama
-from colorama import Fore, Style, init
+from colorama import Fore, Style
 
 rclpy.init()
 
@@ -11,15 +11,15 @@ n = Node('test_logging')
 colorama.init(autoreset=True)
 
 n.get_logger().info("normal")
-n.get_logger().info(Fore.RED + Style.BRIGHT + "bold and red!")
+n.get_logger().info("\033[31m\033[1mbold and red!")
 n.get_logger().info("normal again")
 
 n.get_logger().warning("normal")
-n.get_logger().warning(Fore.RED + Style.BRIGHT + "bold and red!")
+n.get_logger().warning("\033[31m\033[1mbold and red!")
 n.get_logger().warning("normal again")
 
 n.get_logger().error("normal")
-n.get_logger().error(Fore.RED + Style.BRIGHT + "bold and red!")
+n.get_logger().error("\033[31m\033[1mbold and red!")
 n.get_logger().error("normal again")
 
 # Ensure the messages make it to rosout before the script dies


### PR DESCRIPTION
I ported this from #26 to rolling :)

# Motivation
I like to print things with color, using Colorama in python this is super easy.

```
from colorama import Fore, Style, init
import colorama
colorama.init(autoreset=True)
rospy.loginfo(Fore.RED + Style.BRIGHT + "bold and red!")
```

However, this would shows up in the rqt console with no color and lots of ugly ansi codes

# What this does

makes foreground/background color and bold work, via the standard model/view abstraction mechanisms. One pitfall could be the regex I came up with it. It's possible it has false positives.

Here's a screenshot of what it looks like for me with some test logs messages

![2020-09-08-002906_1909x203_scrot](https://user-images.githubusercontent.com/4010770/92433207-5bf79100-f16a-11ea-8abd-b1f7b3d2caa2.png)
