### PR TITLE
remove residual imports in colored output test-file

### DIFF
--- a/test/test_colored_logging.py
+++ b/test/test_colored_logging.py
@@ -1,14 +1,10 @@
 import time
 import rclpy
 from rclpy.node import Node
-import colorama
-from colorama import Fore, Style
 
 rclpy.init()
 
 n = Node('test_logging')
-
-colorama.init(autoreset=True)
 
 n.get_logger().info("normal")
 n.get_logger().info("\033[31m\033[1mbold and red!")


### PR DESCRIPTION
To allow the build-farm to run correctly the usage of colorama inside the code itself was changed to use raw ANSI escape codes.
However, the imports and inits remained, which caused issues in the CI system.
Just removing those should fix that problem.